### PR TITLE
feat: inject Tailwind styles in widget build

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,15 @@
 import './tailwind/theme.css'
+import styles from './tailwind/theme.css?inline'
 export * from './components'
+
+/**
+ * Automatically inject the component styles when the library is imported.
+ * This allows consumers to use the widget without manually importing the
+ * generated CSS file.
+ */
+if (typeof document !== 'undefined' && !document.querySelector('style[data-fidebe]')) {
+  const style = document.createElement('style')
+  style.setAttribute('data-fidebe', '')
+  style.textContent = styles
+  document.head.append(style)
+}


### PR DESCRIPTION
## Summary
- auto-inject compiled TailwindCSS when library loads
- keep generated CSS build for optional manual import

## Testing
- `pnpm run build:lib`
- `pnpm test run` *(fails: No test files found)*
- `pnpm lint`
- `pnpm format` *(fails: `--organize-imports-enabled` is not expected)*

------
https://chatgpt.com/codex/tasks/task_e_68933b88a454832c98e0e0ab9c88e6f2